### PR TITLE
Test the no_op function from util.py to ensure it doesn't modify argu…

### DIFF
--- a/tests/components/group/test_platform_setups.py
+++ b/tests/components/group/test_platform_setups.py
@@ -1,0 +1,22 @@
+"""Tests for platform setups in the group component."""
+from homeassistant.components.group.util import no_op
+
+
+def test_no_op_usage() -> None:
+    """Test the no_op function from util.py to ensure it doesn't modify arguments or return any value."""
+    hass_argument = "hass_value"
+    discovery_info_argument = "discovery_info_value"
+
+    # Duplicate values for comparison after the function call
+    duplicate_hass = hass_argument
+    duplicate_discovery_info = discovery_info_argument
+
+    # Call the no_op function
+    result = no_op(hass_argument, discovery_info_argument)
+
+    # Ensure no_op does not return any value
+    assert result is None
+
+    # Ensure no_op didn't modify its arguments
+    assert hass_argument == duplicate_hass
+    assert discovery_info_argument == duplicate_discovery_info


### PR DESCRIPTION
## Type of change
Just a test. Created a new file to add the test for no-op function I created

- [x] Code quality improvements to existing code or addition of tests



## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

